### PR TITLE
MidwestJS changes + various highlighting/fixes

### DIFF
--- a/slidedeck/package.json
+++ b/slidedeck/package.json
@@ -8,7 +8,8 @@
     "Sean Lomax",
     "Mike Hostetler",
     "Justin Perinovic",
-    "Jeff Sheets"
+    "Jeff Sheets",
+    "Travis Martensen"
   ],
   "license": "MIT",
   "scripts": {

--- a/slidedeck/src/components/slide-deck/slide-deck.tsx
+++ b/slidedeck/src/components/slide-deck/slide-deck.tsx
@@ -65,7 +65,7 @@ export class SlideDeck extends React.Component<SlideDeckProps, SlideDeckState> {
         <div className="slides">
           <section data-state="title">
             <h1>React</h1>
-            <h2>Nebraska.Code() - May 2017</h2>
+            <h2>MidwestJS - August 2017</h2>
           </section>
           {
             slides

--- a/slidedeck/src/slides/00-intro/01.md
+++ b/slidedeck/src/slides/00-intro/01.md
@@ -1,17 +1,10 @@
 ## Workshop Introductions
 
-<strong>[Scott Bock][LScottBock]</strong><br/>
-<strong>[Jeff Sheets][sheetsj]</strong><br/>
 <strong>[Justin Perinovic][justin]</strong><br/>
-<strong>[Sean Lomax][splomax]</strong><br/>
-<strong>[Mike Hostetler][mikehoss42]</strong><br/>
-<strong>[Derek Eskens][snekse]</strong><br/>
+<strong>[Travis Martensen][tmartensen]</strong><br/>
 
-[LScottBock]: https://twitter.com/LScottBock
-[sheetsj]: https://twitter.com/sheetsj
 [justin]: https://www.linkedin.com/in/justin-perinovic-23157871/
-[splomax]: https://twitter.com/splomax
-[mikehoss42]: https://twitter.com/mikehoss42
-[snekse]: https://twitter.com/snekse
+[tmartensen]: https://twitter.com/tmartensen
+
 
 

--- a/slidedeck/src/slides/02-react-basics/00-react-basics.pug
+++ b/slidedeck/src/slides/02-react-basics/00-react-basics.pug
@@ -17,16 +17,16 @@ section
 
 section
   p
-    a(href="http://facebook.github.io/react/docs/glossary.html") More info?
+    a(href="https://facebook.github.io/react/docs/reconciliation.html") More info?
 
 section
   p For a bare-bones React component, we need to do 2 things
   ul
-    li Extend the react Component
-    li Implement render()
+    li Extend the React Component class
+    li Implement <span class="component red">render()</span>
 
 section
-  h2.lower Extend React Component
+  h2.lower React Component
 
 section
   ul
@@ -37,12 +37,12 @@ section
 section
   pre.
     <code class="javascript" data-trim>
-    import React, { Component } from 'react';
+    import React, { Component } from 'react'
     class Hello extends Component {
       render() {...}
     }
 
-    module.exports = Hello;
+    export default Hello
     </code>
 
 section
@@ -58,17 +58,17 @@ section
   h2.lower render()
   ul
     li You should return null (or false) to indicate that you don't want anything rendered
-    li React renders a &lt;noscript&gt; tag to work with our current diffing algorithm
-    li When returning null or false, React.findDOMNode(this) will return null
+    li React renders a <span class="component red">&lt;noscript&gt;</span> tag to work with our current diffing algorithm
+    li When returning null or false, <span class="component red">ReactDOM.findDOMNode(this)</span> will return null
 
 section
   h2.lower render()
   ul
     li Should be pure
     li Should not modify component state
-    li Should return the same result each time it's invoked
+    li Should return the same result each time it is invoked
     li Should not read from or write to the DOM
-    li Work should be performed in componentDidMount() or the other lifecycle methods
+    li Work should be performed in <span class="component red">componentDidMount()</span> or the other lifecycle methods
 
 section
   h2.lower constructor
@@ -81,20 +81,20 @@ section
   pre.
     <code class="javascript" data-trim>
     constructor(props) {
-      super(props);
+      super(props)
       this.state = {
         saveText: 'Update',
         employee: {},
         errors: {}
-      };
+      }
     }
     </code>
 
 section
   h2.lower defaultProps
   ul
-    li Values in the mapping will be set on this.props if that prop is not specified by the parent component
-    li This invoked before any instances are created and therefore it can't rely on this.props
+    li Values in the mapping will be set on <span class="component red">this.props</span> if that prop is not specified by the parent component
+    li This invoked before any instances are created and therefore it can't rely on <span class="component red">this.props</span>
 
 section
   pre.
@@ -112,8 +112,8 @@ section
 section
   h2.lower propTypes: {}
   ul
-    li The propTypes object allows you to validate props being passed to your components
-    li Defined in a similar matter to defaultProps
+    li The <span class="component red">propTypes</span> object allows you to validate props being passed to your components
+    li Defined in a similar matter to <span class="component red">defaultProps</span>
 
 section
   pre.
@@ -159,20 +159,20 @@ section
 section
   p Since JSX is a superset of JavaScript, identifiers like class and for as XML attribute names is discouraged
   ul
-    li htmlFor = for
-    li className = class
+    li <span class="component red">htmlFor</span> instead of <span class="component red">for</span>
+    li <span class="component red">className</span> instead of  <span class="component red">class</span>
 
 section
   h2 Data: State vs. Props
 
 section
   ul
-    li "props" are the data you pass into your component via attributes
+    li <span class="component red">props</span> are the data you pass into your component via attributes
     li Used for application data that you need to display or manage with your component
 
 section
   ul
-    li "state" is your component's internally scoped ... state
+    li <span class="component red">state</span> is your component's internally scoped ... state
     li Used for the behavior of your component: open, disabled, submitted, etc.
 
 section
@@ -194,7 +194,7 @@ section
           onSave={this.saveEmployee}
           validate={this.validate}
           toggleAdmin={this.toggleAdmin} /&gt;
-      );
+      )
     }
 
     </code>
@@ -210,17 +210,17 @@ section
   h2 Mounting
   p These methods are called when an instance of a component is being created and inserted into the DOM:
   ol
-    li constructor()
-    li componentWillMount()
-    li render()
-    li componentDidMount()
+    li <span class="component red">constructor()</span>
+    li <span class="component red">componentWillMount()</span>
+    li <span class="component red">render()</span>
+    li <span class="component red">componentDidMount()</span>
 
 section
   h3.lower componentWillMount()
   ul
-    li Invoked immediately before mounting occurs -- before render()
-    li If you call setState within this method, render() will see the updated state
-    li Since its before render, setState won't cause a "re-render"
+    li Invoked immediately before mounting occurs -- before <span class="component red">render()</span>
+    li If you call <span class="component red">setState()</span> within this method, <span class="component red">render()</span> will see the updated state
+    li Since it happens before <span class="component red">render()</span>, <span class="component red">setState()</span> won't cause a "re-render"
 
 section
   h3.lower render()
@@ -229,19 +229,19 @@ section
   h3.lower componentDidMount()
   ul
     li Invoked immediately after the initial rendering occurs
-    li Setting state will cause "re-render"
+    li Setting state via <span class="component red">this.setState()</span> will cause "re-render"
     li Place to integrate with other JS frameworks
-    li Place to Send AJAX requests
+    li Place to make AJAX requests
 
 section
   h2 Updating:
   p An update can be caused by changes to props or state.
   ol
-    li componentWillReceiveProps()
-    li shouldComponentUpdate()
-    li componentWillUpdate()
-    li render()
-    li componentDidUpdate()
+    li <span class="component red">componentWillReceiveProps()</span>
+    li <span class="component red">shouldComponentUpdate()</span>
+    li <span class="component red">componentWillUpdate()</span>
+    li <span class="component red">render()</span>
+    li <span class="component red">componentDidUpdate()</span>
 
 section
   h4.lower componentWillReceiveProps(object nextProps)
@@ -253,22 +253,22 @@ section
   h4.lower componentWillReceiveProps(object nextProps)
   ul
     li Used to react to a prop transition
-    li This happens before render() is called when updating the state using this.setState()
-    li The old props can be accessed via this.props
-    li Calling this.setState() within this function will not trigger an additional render
+    li This happens before <span class="component red">render()</span> is called when updating the state using <span class="component red">this.setState()</span>
+    li The old props can be accessed via <span class="component red">this.props</span>
+    li Calling <span class="component red">this.setState()</span> within this function will not trigger an additional render
 
 section
   h4.lower shouldComponentUpdate(object nextProps, object nextState)
   ul
     li Invoked before rendering when new props or state are being received
-    li This method is not called for the initial render or when forceUpdate is used
+    li This method is not called for the initial render or when <span class="component red">forceUpdate</span> is used
 
 section
   h4.lower shouldComponentUpdate(object nextProps, object nextState)
   ul
-    li Return false when you're certain that the transition to the new props and state will not require a component update
-    li render() will be completely skipped until the next state change
-    li componentWillUpdate() and componentDidUpdate() will not be called
+    li Return <span class="component red">false</span> when you're certain that the transition to the new props and state will not require a component update
+    li <span class="component red">render()</span> will be completely skipped until the next state change
+    li <span class="component red">componentWillUpdate()</span> and <span class="component red">componentDidUpdate()</span> will not be called
 
 section
   h4.lower componentWillUpdate(object nextProps, object nextState)
@@ -279,8 +279,8 @@ section
 section
   h4.lower componentWillUpdate(object nextProps, object nextState)
   ul
-    li Cannot use this.setState() in this method
-    li If you need to update state in response to a prop change, use componentWillReceiveProps instead
+    li Cannot use <span class="component red">this.setState()</span> in this method
+    li If you need to update state in response to a prop change, use <span class="component red">componentWillReceiveProps()</span> instead
 
 section
   h4.lower render()
@@ -300,10 +300,11 @@ section
     li Invoked immediately before a component is unmounted from the DOM
     li Perform any necessary cleanup in this method
   ul
-    li Invalidating timers
-    li Cleaning up any DOM elements that were created in componentDidMount()
+    li Invalidate timers if necessary
+    li Clean up any DOM elements that were created in <span class="component red">componentDidMount()</span>
 
-
+section
+  h1.lower Test Helpers
 
 section
   h2.lower Enzyme
@@ -316,16 +317,16 @@ section
 section
   pre.
     <code class="javascript" data-trim>
-    import { shallow, mount } from 'enzyme';
+    import { shallow, mount } from 'enzyme'
     </code>
 
 section
   h4.lower Enzyme render testing
   ul
-    li Shallow
+    li <span class="component red">shallow()</span>
       ul
         li Isolate your test by not rendering any child components
-    li Mount
+    li <span class="component red">mount()</span>
       ul
         li More of an 'integration' test
         li Test child component rendering
@@ -341,15 +342,15 @@ section
         hasErrors={spies.hasErrors}
         toggleAdmin={spies.toggleAdmin}
         onSave={spies.onSave} /&gt;
-    );
+    )
 
     </code>
 
 section
   h2.lower Jest Expect
   ul
-    li Default set of expect() assertions included in Jest
-    li toBeTruthy(), toBeFalsy(), toHaveLength(), toEqual(), etc...
+    li Default set of <span class="component red">expect()</span> assertions included in Jest
+    li <span class="component red">toBeTruthy(), toBeFalsy(), toHaveLength(), toEqual()</span>, etc...
     li
       a(href="http://facebook.github.io/jest/docs/expect.html") Jest Expect API
 
@@ -359,7 +360,7 @@ section
     li Test that the component renders successfully
   pre.
     <code class="javascript" data-trim>
-    expect(shallow(<Hello />)).toHaveLength(1);
+    expect(shallow(<Hello />)).toHaveLength(1)
 
     </code>
 
@@ -377,7 +378,7 @@ section
     li Returns true if the text is anywhere in the component
   pre.
     <code class="javascript" data-trim>
-    expect(shallow(&lt;Hello />)).toIncludeText('Howdy');
+    expect(shallow(&lt;Hello />)).toIncludeText('Howdy')
 
     </code>
 
@@ -387,7 +388,7 @@ section
     li Returns true if the JSX element is in the component
   pre.
     <code class="javascript" data-trim>
-    expect(shallow(&lt;Hello />)).toContainReact(&lt;td>Howdy&lt;/td>);
+    expect(shallow(&lt;Hello />)).toContainReact(&lt;td>Howdy&lt;/td>)
 
     </code>
 
@@ -398,9 +399,9 @@ section
   pre.
     <code class="javascript" data-trim>
     //Find first Route in rendered App
-    const route = shallow(&lt;App />).find('Route').at(0);
+    const route = shallow(&lt;App />).find('Route').at(0)
 
-    expect(route).toHaveProp('path', '/projects');
+    expect(route).toHaveProp('path', '/projects')
 
     </code>
 
@@ -414,7 +415,7 @@ section
   pre.
     <code class="javascript" data-trim>
     //Finds all rows with css class 'odd'
-    expect(comp.find('tr.odd')).toHaveLength(1);
+    expect(comp.find('tr.odd')).toHaveLength(1)
 
     </code>
 

--- a/slidedeck/src/slides/03-react-router/00-react-router.pug
+++ b/slidedeck/src/slides/03-react-router/00-react-router.pug
@@ -4,10 +4,10 @@ section
 section
   p Since our backend doesn't serve different "pages", how do we handle different URLs?
   ul
-    li.monospace /
-    li.monospace /login
-    li.monospace /secure/employees
-    li.monospace /secure/timesheets
+    li.monospace <span class="component red">/</span>
+    li.monospace <span class="component red">/login</span>
+    li.monospace <span class="component red">/secure/employees</span>
+    li.monospace <span class="component red">/secure/timesheets</span>
 
 
 - var routeTransition = "<span style='color:#999'>=></span>";
@@ -18,11 +18,11 @@ section
     <br/>to transition the application
   ul(style="list-style-type:none")
     li.monospace
-      p /#inbox !{routeTransition} /#sent <br/>
+      p <span class="component red">/#inbox</span> !{routeTransition} <span class="component red">/#sent</span> <br/>
     li.monospace
-      p /amegala !{routeTransition} /objectpartners
+      p <span class="component red">/opi</span> !{routeTransition} <span class="component red">/objectpartners</span>
     li.monospace
-      p /moments?cat=1 !{routeTransition} /moments?cat=2
+      p <span class="component red">/moments?cat=1</span> !{routeTransition} <span class="component red">/moments?cat=2</span>
 
 section
   h1.lower react-router
@@ -35,14 +35,14 @@ section
     li Maintains the browser history within the app
     li Able to trigger multiple routes
     li Routes are represented as React Components
-    li Routes provides info to components via props
+    li Routes provides info to components via <span class="component red">props</span>
 
 section
-  h2 react-router component's we'll be covering...
+  h2 react-router components we'll be covering...
 
 section
   h2.lower.component &lt;BrowserRouter&gt;
-  p A type of &lt;Router&gt; that uses the HTML5 history API to keep your UI in sync with the URL.<br/><br/>
+  p A type of <span class="component red">&lt;Router&gt;</span> that uses the HTML5 history API to keep your UI in sync with the URL.<br/><br/>
   p One of 5 different types of Routers available in the react-router library.
 
 
@@ -66,36 +66,36 @@ section
     li Pattern used to match this route against the URL
     li Based on Express-style path strings
       ul
-        li e.g. <span class="component" style="color:#c82506">/employees/:id</span>
+        li e.g. <span class="component red">/employees/:id</span>
         li npm
           a(href="https://www.npmjs.com/package/path-to-regexp")  path-to-regexp
     li.
       If multiple routes match, each will get rendered<br/>
-      &nbsp;(unless defined inside a <span class='monospace'>switch</span>)
+      &nbsp;(unless defined inside a <span class="component red">switch</span>)
 
     li If path not defined, the route will always render
 
 section
   h3.lower component
   ul
-    li The react component to be rendered when the route is active
+    li The React component to be rendered when the route is active
     li Alternative render properties (not covered today):
       ul
-        li <span class="component" style="color:#c82506">render</span> - quick inline function rendering
-        li <span class="component" style="color:#c82506">children</span> - for complex rendering logic needs
+        li <span class="component red">render</span> - quick inline function rendering
+        li <span class="component red">children</span> - for complex rendering logic needs
 
 section
   h3.lower exact & strict
   ul
     li.
-      <span class="component" style="color:#c82506">exact</span> - only matches if an
+      <span class="component red">exact</span> - only matches if an
       <span style="font-style:italic">exact</span> match
     li.
-      <span class="component" style="color:#c82506">strict</span> - requires the trailing slash
+      <span class="component red">strict</span> - requires the trailing slash
       <span style="font-style:italic">exact</span> match
     li.
-      If <span class="component">exact</span> is omitted, a route path of <span class="component">/employees</span>
-      will match a URL of <span class="component">/employees/anything</span>
+      If <span class="component red">exact</span> is omitted, a route path of <span class="component red">/employees</span>
+      will match a URL of <span class="component red">/employees/anything</span>
     li.
       Check the <a href="https://reacttraining.com/react-router/web/api/Route/exact-bool">docs</a> for more info
 
@@ -133,15 +133,15 @@ section
 
 section
   ul
-    li Renders an &lt;a&gt; tag
+    li Renders an <span class="component red">&lt;a&gt;</span> tag
     li Links to a route in the application
     li If you change the path of your route, <br/>you don't have to change your links as well
     li.
-      <span class="component" style="color:#c82506">&lt;NavLink&gt;</span> is a specialized version of &lt;Link&gt;
+      <span class="component red">&lt;NavLink&gt;</span> is a specialized version of <span class="component red">&lt;Link&gt;</span>
     ul
       li Knows when the route it links to is active
       li Dynamic
-        span.component  activeClassName/activeStyle
+        span.component.red  activeClassName/activeStyle
       li Has exact and strict params like a Route
 
 section
@@ -165,32 +165,35 @@ section
 section
   h2.lower Route Props
   p Components receive the following props from Router
-  ul.monospace
-    li match
-    li location
-    li history
+  ul
+    li
+      span.component.red match
+    li 
+      span.component.red location
+    li 
+      span.component.red history
 
 section
   h3.lower match
   p Object containing information about how the Route matched the URL.
   ul
     li
-      <span class="component" style="color:#c82506">path</span> - Path pattern on the Route that matched
+      <span class="component red">path</span> - Path pattern on the Route that matched
       <br/>
       span(style="margin-left:1em; color:#656565;") e.g.&nbsp;
         span.component(style="font-size:0.95em;") /employee/:id
     li
-      <span class="component" style="color:#c82506">url</span> - URL segment that was matched
+      <span class="component red">url</span> - URL segment that was matched
       <br/>
       span(style="margin-left:1em;color:#656565;") e.g.&nbsp;
         span.component(style="font-size:0.95em;") /employee/2
     li
-      <span class="component" style="color:#c82506">params</span> - key/values for the dynamic parts of URL
+      <span class="component red">params</span> - key/values for the dynamic parts of URL
       <br/>
       span(style="margin-left:1em;color:#656565;")
         span.component(style="font-size:0.95em;") /employee/2 =>/employee/:id => {id:2}
     li
-      <span class="component" style="color:#c82506">isExact</span> - true if the entire URL was matched
+      <span class="component red">isExact</span> - true if the entire URL was matched
 
 section
   h3.lower location
@@ -211,11 +214,11 @@ section
 
 section
   p Where we are
-  p.component this.props.location
+  p.component.red this.props.location
   p Where we were
-  p.component this.props.history...
+  p.component.red this.props.history...
   p Where we are going
-  p.component &lt;Link to={location}/&gt;
+  p.component.red &lt;Link to={location}/&gt;
 
 
 section

--- a/slidedeck/src/slides/04-redux/00-redux.pug
+++ b/slidedeck/src/slides/04-redux/00-redux.pug
@@ -6,7 +6,7 @@ section
   ul
     li Single source of truth - object tree in a single store
     li State is read-only - can only be changed by dispatching an action
-    li Changes are made with pure functions called reducers
+    li Changes are made with pure functions called <span class="component red">reducers</span>
 
 section
   h2 Benefits

--- a/slidedeck/src/slides/05-react-forms/00-react-forms.pug
+++ b/slidedeck/src/slides/05-react-forms/00-react-forms.pug
@@ -19,7 +19,7 @@ section
 section
   ul
     li Form components allow listening for changes
-    li Set a callback to the onChange prop
+    li Set a callback to the <span class="component red">onChange</span> prop
     li The callback fires when:
       ul
         li The value changes (every keystroke)
@@ -30,8 +30,8 @@ section
   h2 Controlled Components
   ul
     li React controls state and display
-    li Any &lt;input&gt; with value set is a controlled component
-    li Value of the rendered element will always reflect the value prop
+    li Any <span class="component red">&lt;input&gt;</span> with value set is a controlled component
+    li Value of the rendered element will always reflect the <span class="component red">value</span> prop
   pre.
     <code class="javascript" data-trim>handleCityChange(event) {
       this.setState({city: {value: event.target.value}});
@@ -61,7 +61,7 @@ section
   h2 React Bootstrap Validation
   ul
     li Add a validationState function to return one of success, warning, or error
-    li Add `&lt;FormControl.Feedback />` inside the FormGroup tag
+    li Add <span class="component red">&lt;FormControl.Feedback/></span> inside the FormGroup tag
 
 section
   h3 Validation
@@ -98,14 +98,21 @@ section
     </code>
 
 section
-  h2 Uncontrolled Components
+  h3 Uncontrolled Components
   ul
     li React does not control the state
     li Used for custom behavior
-    li Good for co-existing with non-react libraries
-    li Use a `ref` function to get input value from DOM
+    li Good for co-existing with non-React libraries
+    li Use a <span class="component red">ref</span> function to get input value from DOM
+    li Optionally, use <span class="component red">defaultValue</span> instead of <span class="component red">value</span>, <span class="component red">defaultChecked</span> instead of <span class="component red">checked</span>
   pre.
-    <code class="html" data-trim>&lt;input type="text" ref={(input) => this.textInput = input} />
+    <code class="javascript" data-trim>&lt;form onSubmit={this.handleSubmit}&gt;
+      &lt;input type="text" ref={(input) => this.name = input} />
+    &lt;/form&gt;
+
+    handleSubmit(event) {
+      console.log(`Input value: ${this.name}`)
+    }
     </code>
 
 section


### PR DESCRIPTION
Changes made for MidwestJS workshop. Added a bunch of highlighting. Corrected typos. Corrected React glossary link. Removed semicolons from code snippets for a consistent ES6 style.